### PR TITLE
Add code 127 as non failure code

### DIFF
--- a/roles/groovy/tasks/main.yml
+++ b/roles/groovy/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: check groovy installed
   shell: type groovy
   register: verify_groovy
-  failed_when: verify_groovy.rc not in [0, 1]
+  failed_when: verify_groovy.rc not in [0, 1, 127]
   changed_when: verify_groovy | failed
 - name: install groovy binary
   when: verify_groovy | changed

--- a/roles/groovy/tasks/main.yml
+++ b/roles/groovy/tasks/main.yml
@@ -2,7 +2,7 @@
   shell: type groovy
   register: verify_groovy
   failed_when: verify_groovy.rc not in [0, 1, 127]
-  changed_when: verify_groovy | failed
+  changed_when: verify_groovy.rc in [1, 127]
 - name: install groovy binary
   when: verify_groovy | changed
   get_url:
@@ -10,7 +10,7 @@
     dest: /tmp/{{groovy_dir_name}}.zip
 - name: unarchive groovy binary zip
   sudo: yes
-  when: verify_groovy | failed
+  when: verify_groovy | changed
   unarchive:
     copy: no
     src: /tmp/{{groovy_dir_name}}.zip


### PR DESCRIPTION
type command in dash returns 127 when command not found.
type in bash will return 1 instead.

@skohar please review
