### PR TITLE
Add playbook for circle ci; playbook without mono

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,5 @@ WORKDIR /root
 RUN bash -c 'cp .bashrc .bashrc.old && : >.bashrc'
 RUN git clone https://github.com/code-check/env-builder.git
 WORKDIR /root/env-builder
-RUN ansible-playbook -i hosts-local all.yml
+RUN ansible-playbook -i hosts-local playcircle.yml
 WORKDIR /root

--- a/playcircle.yml
+++ b/playcircle.yml
@@ -1,0 +1,24 @@
+- hosts: all
+  sudo: no
+  roles:
+    - system
+    - clang
+    - git
+    - gcc
+    - go
+    - gpp
+    - gradle
+    - groovy
+    - haskell
+    - java
+    # - mono
+    - node
+    - ocaml
+    - perl
+    - php
+    - python3
+    - ruby
+    - scala
+
+#    - mysql
+#    - postgresql


### PR DESCRIPTION
NO MONO INSTALLATION IN CIRCLE CI !!!

Because of /dev/fuse requirement in mono, it fails always
