### PR TITLE
Move vagrant file and remove sync folder

### DIFF
--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -3,9 +3,8 @@
 
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu1404"
-  config.vm.hostname = "CodeCheck-Env"
+  config.vm.hostname = "envbuilder"
   config.vm.network "private_network", ip: "192.168.33.101"
-  config.vm.synced_folder "data", "/home/vagrant/data", :nfs => true
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--memory", 2048]
   end


### PR DESCRIPTION
Vagrantfile is not part of the ansible, and env-builder don't need sync folder by default.
@skohar please review me
